### PR TITLE
Support reverse proxy

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -7,7 +7,7 @@ class Api {
 
   constructor() {
     this.axios = Axios.create({
-      baseURL: '/api/v2',
+      baseURL: 'api/v2',
     });
 
     this.axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/src/components/MainToolbar.vue
+++ b/src/components/MainToolbar.vue
@@ -13,7 +13,7 @@
     >
       <img
         class="icon"
-        src="/favicon.ico"
+        src="favicon.ico"
       >
       <span class="title hidden-sm-and-down ml-3 mr-5">
         qBittorrent Web UI

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,7 +5,7 @@ module.exports = {
   devServer: {
     port: 8000,
     proxy: {
-      '/api': {
+      'api': {
         target: 'http://qb.test:8080',
       },
     },

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   outputDir: 'dist/public',
+  publicPath: './',
 
   devServer: {
     port: 8000,

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,7 +5,7 @@ module.exports = {
   devServer: {
     port: 8000,
     proxy: {
-      'api': {
+      '/api': {
         target: 'http://qb.test:8080',
       },
     },


### PR DESCRIPTION
这个改动用于添加反向代理的支持，之前的配置使用了绝对路径，在调用API和下载资源的时候会失败。改成了相对路径来解决这些问题。在反向代理和非反向代理下测试均可载入

同时也可以修复 #23 #24