### PR TITLE
Support setting file priority in content view

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -83,6 +83,17 @@ class Api {
     return this.axios.post('/app/setPreferences', data);
   }
 
+  public setTorrentFilePriority(hash: string, idList: Array<number>, priority: number) {
+    const idListStr = idList.join('|');
+    const params = {
+      hash,
+      id: idListStr,
+      priority,
+    }
+
+    return this.axios.get('/torrents/filePrio', { params });
+  }
+
   public getLogs(lastId?: number) {
     const params = {
       last_known_id: lastId,

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -85,13 +85,14 @@ class Api {
 
   public setTorrentFilePriority(hash: string, idList: Array<number>, priority: number) {
     const idListStr = idList.join('|');
-    const params = {
+    const params: any = {
       hash,
       id: idListStr,
       priority,
     }
 
-    return this.axios.get('/torrents/filePrio', { params });
+    const data = new URLSearchParams(params);
+    return this.axios.post(`/torrents/filePrio`, data).then(Api.handleResponse);
   }
 
   public getLogs(lastId?: number) {

--- a/src/components/dialogs/TorrentContent.vue
+++ b/src/components/dialogs/TorrentContent.vue
@@ -1,25 +1,25 @@
 <template>
-  <v-treeview
-    open-on-click
-    :items="fileTree"
-    :value="selected"
-    selection-type="leaf"
-    selectable
-    dense
-    @input="selectChanged"
-  >
-    <template v-slot:prepend="row">
-      <v-icon v-text="getRowIcon(row)" />
-    </template>
-    <template v-slot:append="row">
-      <span>
-        [{{ getTotalSize(row.item) | size }}]
-      </span>
-      <span class="progress">
-        {{ getTotalProgress(row.item) | progress }}
-      </span>
-    </template>
-  </v-treeview>
+  <div class="torrent-content">
+    <v-treeview
+      open-on-click
+      :items="fileTree"
+      :value="selected"
+      selectable
+      @input="selectChanged"
+    >
+      <template v-slot:prepend="row">
+        <v-icon v-text="getRowIcon(row)" />
+      </template>
+      <template v-slot:append="row">
+        <span>
+          [{{ getTotalSize(row.item) | size }}]
+        </span>
+        <span class="progress">
+          {{ getTotalProgress(row.item) | progress }}
+        </span>
+      </template>
+    </v-treeview>
+  </div>
 </template>
 
 <script lang="ts">
@@ -27,7 +27,7 @@ import { groupBy, xor } from 'lodash';
 import api from '../../Api';
 import BaseTorrentInfo from './baseTorrentInfo'
 import Component from 'vue-class-component';
-import { Prop, Emit } from 'vue-property-decorator';
+import { Prop } from 'vue-property-decorator';
 
 enum EFilePriority {
   notDownload = 0,
@@ -111,7 +111,6 @@ export default class TorrentContent extends BaseTorrentInfo {
     return size;
   }
 
-  @Emit('input')
   selectChanged(items: Array<number>) {
     const previous = this.selected;
     const diff = xor(previous, items);

--- a/src/components/dialogs/TorrentContent.vue
+++ b/src/components/dialogs/TorrentContent.vue
@@ -1,37 +1,47 @@
 <template>
-  <div class="torrent-content">
-    <v-treeview
-      open-on-click
-      :items="fileTree"
-    >
-      <template v-slot:prepend="row">
-        <v-icon v-text="getRowIcon(row)" />
-      </template>
-      <template v-slot:append="row">
-        <span>
-          [{{ getTotalSize(row.item) | size }}]
-        </span>
-        <span class="progress">
-          {{ getTotalProgress(row.item) | progress }}
-        </span>
-      </template>
-    </v-treeview>
-  </div>
+  <v-treeview
+    open-on-click
+    :items="fileTree"
+    :value="selected"
+    selection-type="leaf"
+    selectable
+    dense
+    @input="selectChanged"
+  >
+    <template v-slot:prepend="row">
+      <v-icon v-text="getRowIcon(row)" />
+    </template>
+    <template v-slot:append="row">
+      <span>
+        [{{ getTotalSize(row.item) | size }}]
+      </span>
+      <span class="progress">
+        {{ getTotalProgress(row.item) | progress }}
+      </span>
+    </template>
+  </v-treeview>
 </template>
 
 <script lang="ts">
-import { groupBy } from 'lodash';
+import { groupBy, xor } from 'lodash';
 import api from '../../Api';
 import BaseTorrentInfo from './baseTorrentInfo'
 import Component from 'vue-class-component';
-import { Prop } from 'vue-property-decorator';
+import { Prop, Emit } from 'vue-property-decorator';
+
+enum EFilePriority {
+  notDownload = 0,
+  normal = 1,
+  high = 6,
+  maximal = 7
+}
 
 /* eslint-disable camelcase */
 interface File {
   name: string;
   size: number;
   progress: number;
-  priority: number;
+  priority: EFilePriority;
   is_seed: boolean;
   piece_range: Array<number>;
   availability: number;
@@ -39,6 +49,7 @@ interface File {
 /* eslint-disable camelcase */
 
 interface TreeItem {
+  id: number;
   name: string;
   item?: File;
   children?: Array<TreeItem>;
@@ -50,6 +61,8 @@ interface Data {
 
 const FILE_KEY = '/FILE/';
 
+const UNWANTED_FILE = '.unwanted';
+
 @Component
 export default class TorrentContent extends BaseTorrentInfo {
   @Prop(String)
@@ -57,8 +70,20 @@ export default class TorrentContent extends BaseTorrentInfo {
 
   files: File[] = []
 
-  get fileTree() {
+  get fileTree(): TreeItem[] {
     return this.buildTree(this.files, 0);
+  }
+
+  get selected(): number[] {
+    const list: number[] = [];
+
+    this.files.forEach((item, index) => {
+        if(item.priority !== EFilePriority.notDownload) {
+          list.push(index);
+        }
+      })
+
+    return list;
   }
 
   async getFiles() {
@@ -84,6 +109,18 @@ export default class TorrentContent extends BaseTorrentInfo {
     }
 
     return size;
+  }
+
+  @Emit('input')
+  selectChanged(items: Array<number>) {
+    const previous = this.selected;
+    const diff = xor(previous, items);
+
+    if(diff.length == 0) return;
+
+    api.setTorrentFilePriority(this.hash, diff,
+     items.length > previous.length ?
+      EFilePriority.normal : EFilePriority.notDownload);
   }
 
   getTotalProgress(item: TreeItem) {
@@ -115,6 +152,10 @@ export default class TorrentContent extends BaseTorrentInfo {
     return name.substring(start, index);
   }
 
+  getFileIndex(item: File): number {
+    return this.files.findIndex(value => value.name === item.name);
+  }
+
   buildTree(files: Array<File>, start: number): TreeItem[] {
     if (!files.length) {
       return [];
@@ -124,22 +165,38 @@ export default class TorrentContent extends BaseTorrentInfo {
 
     const result = [];
     for (const [folder, values] of Object.entries(entries)) {
+
+      // Push .unwanted file to current folder, just like original web ui
+      if(folder === UNWANTED_FILE) {
+          for (const item of values) {
+            result.push({
+              id: this.getFileIndex(item),
+              name: item.name.substring(start + folder.length + 1),
+              item,
+            });
+          }
+          continue;
+        }
+
       if (folder !== FILE_KEY) {
         const subTree = this.buildTree(values, start + folder.length + 1);
+        // Offset folder id to making sure it will not influence array content
         result.push({
+          id: this.files.length + start,
           name: folder,
           children: subTree,
         });
         continue;
       }
 
-      for (const item of values) {
-        result.push({
-          name: item.name.substring(start),
-          item,
-        });
+        for (const item of values) {
+          result.push({
+            id: this.getFileIndex(item),
+            name: item.name.substring(start),
+            item,
+          });
+        }
       }
-    }
 
     return result;
   }


### PR DESCRIPTION
<img width="988" alt="image" src="https://user-images.githubusercontent.com/23134797/79669642-7ea30080-81ef-11ea-822e-d010be51af11.png">

支持在 Info - Content 中配置文件优先级（现在只做了是否下载文件，要全加进去似乎会变丑）

顺便对UI做了一个小优化，之前每个TreeviewNode的上下部分会被裁掉一部分，去掉最外层包着的 `<div class="torrent-content">` 就好了

使用的 [API](https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation#set-file-priority)