### PR TITLE
Several misc fixes

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -121,6 +121,10 @@ class Api {
     return this.actionTorrents('resume', hashes);
   }
 
+  public setForceStartTorrents(hashes: string[]) {
+    return this.actionTorrents('setForceStart', hashes, {value:'true'});
+  }
+
   public reannounceTorrents(hashes: string[]) {
     return this.actionTorrents('reannounce', hashes);
   }

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -38,6 +38,10 @@ class Api {
     return this.axios.get('/app/preferences');
   }
 
+  public shutdownApplication() {
+    return this.axios.get('/app/shutdown');
+  }
+
   public getMainData(rid?: number) {
     const params = {
       rid,

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -488,15 +488,6 @@ export default class Torrents extends Vue {
     if (!this.hasSelected) {
       this.selectedRows = this.allTorrents;
     }
-    const v = await this.asyncShowDialog({
-      title: 'Reannounce Torrents',
-      text: 'Are you sure want to reannounce torrents?',
-      type: DialogType.OkCancel,
-    });
-
-    if (!v) {
-      return;
-    }
 
     await api.reannounceTorrents(this.selectedHashes);
 

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -33,6 +33,16 @@
         >
           <v-icon>mdi-pause</v-icon>
         </v-btn>
+
+        <v-btn
+          icon
+          @click="forceStartTorrents"
+          :title="$t('force_start')"
+          :disabled="!hasSelected"
+        >
+          <v-icon>mdi-play-speed</v-icon>
+        </v-btn>
+
         <v-divider
           vertical
           inset
@@ -464,6 +474,10 @@ export default class Torrents extends Vue {
 
   async resumeTorrents() {
     await api.resumeTorrents(this.selectedHashes);
+  }
+
+  async forceStartTorrents() {
+    await api.setForceStartTorrents(this.selectedHashes);
   }
 
   async pauseTorrents() {

--- a/src/components/drawer/DrawerFooter.vue
+++ b/src/components/drawer/DrawerFooter.vue
@@ -59,8 +59,7 @@
       <v-btn
         icon
         @click="triggerApplicationShutdown"
-        :title="$t('triggerApplicationShutdown')"
-      >
+        :title="$t('trigger_application_shutdown')">
         <v-icon> mdi-power-plug-off</v-icon>
       </v-btn>
     </div>

--- a/src/components/drawer/DrawerFooter.vue
+++ b/src/components/drawer/DrawerFooter.vue
@@ -56,6 +56,13 @@
       >
         <v-icon v-text="darkModeIcon" />
       </v-btn>
+      <v-btn
+        icon
+        @click="triggerApplicationShutdown"
+        :title="$t('triggerApplicationShutdown')"
+      >
+        <v-icon> mdi-power-plug-off</v-icon>
+      </v-btn>
     </div>
   </div>
 </template>
@@ -65,6 +72,7 @@ import Vue from 'vue'
 import Component from 'vue-class-component';
 import { mapMutations, mapActions } from 'vuex';
 import { Watch } from 'vue-property-decorator';
+import api from '../../Api';
 
 import { tr, translations, defaultLocale, LocaleKey } from '@/locale';
 import { DialogType, DialogConfig, SnackBarConfig, ConfigPayload } from '@/store/types';
@@ -160,6 +168,20 @@ export default class DrawerFooter extends Vue {
       value: theme.dark,
     });
   }
+
+  async triggerApplicationShutdown() {
+    const v = await this.asyncShowDialog({
+      title:  tr('dialog.trigger_exit_qb.title'),
+      text:  tr('dialog.trigger_exit_qb.text'),
+      type: DialogType.OkCancel,
+    });
+
+    if (!v) {
+      return;
+    }
+    await api.shutdownApplication();
+  }
+
 
   @Watch('currentLocale')
   onCurrentLocaleChanged(v: AllLocaleKey) {

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -23,7 +23,7 @@ export default {
   refresh: 'Refresh',
   location: 'Location',
   rename: 'Rename',
-  triggerApplicationShutdown: 'Exit qBittorrent',
+  trigger_application_shutdown: 'Exit qBittorrent',
   reannounce: 'Reannounce',
   recheck: 'Recheck',
 

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -23,7 +23,7 @@ export default {
   refresh: 'Refresh',
   location: 'Location',
   rename: 'Rename',
-
+  triggerApplicationShutdown: 'Exit qBittorrent',
   reannounce: 'Reannounce',
   recheck: 'Recheck',
 
@@ -89,6 +89,10 @@ export default {
   },
 
   dialog: {
+    trigger_exit_qb: {
+      title: 'Exit qBittorrent',
+      text: 'Are you sure you want to exit qBittorrent?'
+    },
     add_torrents: {
       placeholder: 'Upload torrents by drop them here,\nor click attachment button at right to select.',
       hint: 'One link per line',

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -15,6 +15,7 @@ export default {
   todo: 'To Do',
   resume: 'Resume',
   pause: 'Pause',
+  force_start: 'Force Start',
   info: 'Info',
   reset: 'Reset',
   login: 'Login',

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -15,6 +15,7 @@ export default {
   todo: '待办',
   resume: '恢复',
   pause: '暂停',
+  force_start: '强制继续',
   info: '信息',
   reset: '重置',
   login: '登录',

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -23,7 +23,7 @@ export default {
   refresh: '刷新',
   location: '位置',
   rename: '重命名',
-  triggerApplicationShutdown: '退出qBittorrent',
+  trigger_application_shutdown: '退出qBittorrent',
   reannounce: '重新通告',
   recheck: '重新检查',
 

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -23,7 +23,7 @@ export default {
   refresh: '刷新',
   location: '位置',
   rename: '重命名',
-
+  triggerApplicationShutdown: '退出qBittorrent',
   reannounce: '重新通告',
   recheck: '重新检查',
 
@@ -89,6 +89,10 @@ export default {
   },
 
   dialog: {
+    trigger_exit_qb: {
+      title: '退出 qBittorrent',
+      text: '您确定要退出qBittorrent吗？'
+    },
     add_torrents: {
       placeholder: '将种子拖到这里上传，\n或者点击右边的附件图标来选择。',
       hint: '每行一个链接',

--- a/src/protocolHandler.ts
+++ b/src/protocolHandler.ts
@@ -8,7 +8,7 @@ function registerProtocolHandler() {
   }
 
   try {
-    navigator.registerProtocolHandler('magnet', location.origin + '#url=%s', document.title);
+    navigator.registerProtocolHandler('magnet', location.origin + '#download=%s', document.title);
   } catch (e) {
     log('Register protocol handler failed.', e);
   }
@@ -20,12 +20,12 @@ function checkDownloadUrl() {
   }
 
   const params = new URLSearchParams(location.hash.substring(1));
-  const url = params.get('url')
+  const url = params.get('download')
   if (!url) {
     return null;
   }
 
-  params.delete('url');
+  params.delete('download');
   location.hash = '#' + params.toString()
   return url
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,10 @@
 import { StateType } from './consts';
 import { Torrent } from './types';
 
-const dlState = ['downloading', 'metaDL', 'stalledDL', 'checkingDL', 'pausedDL', 'queuedDL', 'forceDL', 'allocating'];
-const upState = ['uploading', 'stalledUP', 'checkingUP', 'queuedUP', 'forceUP'];
-const completeState = ['uploading', 'stalledUP', 'checkingUP', 'pausedUP', 'queuedUP', 'forceUP'];
-const activeState = ['metaDL', 'downloading', 'forceDL', 'uploading', 'forcedUP', 'moving'];
+const dlState = ['downloading', 'metaDL', 'stalledDL', 'checkingDL', 'pausedDL', 'queuedDL', 'forcedDL', 'allocating'];
+const upState = ['uploading', 'stalledUP', 'checkingUP', 'queuedUP', 'forcedUP'];
+const completeState = ['uploading', 'stalledUP', 'checkingUP', 'pausedUP', 'queuedUP', 'forcedUP'];
+const activeState = ['metaDL', 'downloading', 'forcedDL', 'uploading', 'forcedUP', 'moving'];
 const errorState = ['error', 'missingFiles'];
 
 export function torrentIsState(type: StateType, state: string) {


### PR DESCRIPTION
- fix typo to show forced state torrents
- add function and button for torrents to force seeding/downloading (#33)
- add function and button for qBittorrent to shut down safely for nox users
- stop confirming torrents reannouncing, it's not necessary
- use official syntax of protocolHandler (from `qb-web://#url=%magnet%` to `qb-web://#download=%magnet%` ), since there are currently no button to register right now

