### PR TITLE
Correct several icons to better match their usage

### DIFF
--- a/src/components/AddForm.vue
+++ b/src/components/AddForm.vue
@@ -11,7 +11,7 @@
       class="btn-add"
       :class="{'with-footer': $vuetify.breakpoint.smAndUp}"
     >
-      <v-icon>mdi-link-plus</v-icon>
+      <v-icon>mdi-plus</v-icon>
     </v-btn>
     <v-dialog
       v-model="state.isOpen"
@@ -22,7 +22,7 @@
     >
       <v-card>
         <v-card-title class="headline">
-          <v-icon class="mr-2">mdi-link-plus</v-icon>
+          <v-icon class="mr-2">mdi-plus</v-icon>
           <span>{{ state.downloadItem && state.downloadItem.title || $t('title.add_torrents') }}</span>
         </v-card-title>
         <v-card-text class="pb-0">

--- a/src/components/AddForm.vue
+++ b/src/components/AddForm.vue
@@ -120,7 +120,7 @@
                 >
                   <v-checkbox
                     :label="$t('label.start_torrent')"
-                    prepend-icon="mdi-play"
+                    prepend-icon="mdi-download-multiple"
                     :input-value="!params.paused"
                     @change="setParams('paused', !$event)"
                   />
@@ -131,7 +131,7 @@
                   v-if="!phoneLayout || showMore"
                 >
                   <v-checkbox
-                    prepend-icon="mdi-data-matrix-scan"
+                    prepend-icon="mdi-barcode-off"
                     :label="$t('label.skip_hash_check')"
                     :input-value="params.skip_checking"
                     @change="setParams('skip_checking', $event)"

--- a/src/components/AddForm.vue
+++ b/src/components/AddForm.vue
@@ -120,7 +120,7 @@
                 >
                   <v-checkbox
                     :label="$t('label.start_torrent')"
-                    prepend-icon="mdi-play-pause"
+                    prepend-icon="mdi-play"
                     :input-value="!params.paused"
                     @change="setParams('paused', !$event)"
                   />
@@ -131,7 +131,7 @@
                   v-if="!phoneLayout || showMore"
                 >
                   <v-checkbox
-                    prepend-icon="mdi-progress-check"
+                    prepend-icon="mdi-data-matrix-scan"
                     :label="$t('label.skip_hash_check')"
                     :input-value="params.skip_checking"
                     @change="setParams('skip_checking', $event)"
@@ -144,7 +144,7 @@
                   >
                     <v-checkbox
                       :label="$t('label.in_sequential_order')"
-                      prepend-icon="mdi-sort-descending"
+                      prepend-icon="mdi-sort-ascending"
                       :ipnut-value="params.sequentialDownload"
                       @change="setParams('sequentialDownload', $event)"
                     />

--- a/src/components/AddForm.vue
+++ b/src/components/AddForm.vue
@@ -91,7 +91,7 @@
                 >
                   <v-combobox
                     :label="$t('category', 1)"
-                    prepend-icon="mdi-folder"
+                    prepend-icon="mdi-shape-plus"
                     clearable
                     hide-no-data
                     :items="categoryItems"
@@ -106,7 +106,7 @@
                 >
                   <v-text-field
                     :label="$t('location')"
-                    prepend-icon="mdi-folder-marker"
+                    prepend-icon="mdi-folder-download"
                     clearable
                     :disabled="params.autoTMM"
                     :placeholder="defaultPath"

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -211,7 +211,7 @@ export default class Drawer extends Vue {
     return [{
       key: '',
       title: tr('uncategorized'),
-      icon: 'mdi-folder'
+      icon: 'mdi-view-grid'
     }].concat(this.allCategories.map((category) => {
       let value = this.torrentGroupByCategory[category.key];
       if (isUndefined(value)) {
@@ -221,7 +221,7 @@ export default class Drawer extends Vue {
       const title = `${category.name} (${value.length})`;
       const append = `[${size}]`;
       return {
-        icon: 'mdi-folder-star', title, key: category.key, append,
+        icon: 'mdi-view-grid-outline', title, key: category.key, append,
       };
     }));
   }
@@ -269,7 +269,7 @@ export default class Drawer extends Vue {
       select: 'category',
       children: [
         {
-          icon: 'mdi-folder', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
+          icon: 'mdi-view-grid', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
         },
         ...this.buildCategoryGroup(),
       ],

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -156,7 +156,7 @@ export default class Drawer extends Vue {
   ]
 
   endItems: MenuItem[] = [
-    { icon: 'mdi-delta', title: tr('logs'), click: () => this.updateOptions('showLogs', true) },
+    { icon: 'mdi-file-document-outline', title: tr('logs'), click: () => this.updateOptions('showLogs', true) },
   ]
 
   isDataReady!: boolean

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -152,7 +152,7 @@ export default class Drawer extends Vue {
   readonly value: any
 
   basicItems: MenuItem[] = [
-    { icon: 'mdi-cog-box', title: tr('settings'), click: () => alert(tr('todo')) },
+    { icon: 'mdi-cog-outline', title: tr('settings'), click: () => alert(tr('todo')) },
   ]
 
   endItems: MenuItem[] = [
@@ -168,7 +168,7 @@ export default class Drawer extends Vue {
 
   created() {
     const searchMenuItem = {
-      icon: 'mdi-card-search-outline',
+      icon: 'mdi-text-box-search-outline',
       title: tr('search'),
       click: () => this.updateOptions('showSearch', true)
     };
@@ -182,7 +182,7 @@ export default class Drawer extends Vue {
     }
 
     this.endItems = this.endItems.concat([
-      { icon: 'mdi-rss-box', title: 'RSS', click: () => this.updateOptions('showRss', true) },
+      { icon: 'mdi-rss', title: 'RSS', click: () => this.updateOptions('showRss', true) },
       searchMenuItem,
       { icon: 'mdi-history', title: tr('label.switch_to_old_ui'), click: this.switchUi },
     ])

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -168,7 +168,7 @@ export default class Drawer extends Vue {
 
   created() {
     const searchMenuItem = {
-      icon: 'mdi-text-box-search-outline',
+      icon: 'mdi-text-search',
       title: tr('search'),
       click: () => this.updateOptions('showSearch', true)
     };
@@ -211,7 +211,7 @@ export default class Drawer extends Vue {
     return [{
       key: '',
       title: tr('uncategorized'),
-      icon: 'mdi-view-grid'
+      icon: 'mdi-shape'
     }].concat(this.allCategories.map((category) => {
       let value = this.torrentGroupByCategory[category.key];
       if (isUndefined(value)) {
@@ -221,7 +221,7 @@ export default class Drawer extends Vue {
       const title = `${category.name} (${value.length})`;
       const append = `[${size}]`;
       return {
-        icon: 'mdi-view-grid-outline', title, key: category.key, append,
+        icon: 'mdi-shape-outline', title, key: category.key, append,
       };
     }));
   }
@@ -269,7 +269,7 @@ export default class Drawer extends Vue {
       select: 'category',
       children: [
         {
-          icon: 'mdi-view-grid', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
+          icon: 'mdi-shape', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
         },
         ...this.buildCategoryGroup(),
       ],

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -210,8 +210,9 @@ export default class Drawer extends Vue {
   buildCategoryGroup(): MenuChildrenItem[] {
     return [{
       key: '',
-      name: tr('uncategorized'),
-    }].concat(this.allCategories).map((category) => {
+      title: tr('uncategorized'),
+      icon: 'mdi-folder'
+    }].concat(this.allCategories.map((category) => {
       let value = this.torrentGroupByCategory[category.key];
       if (isUndefined(value)) {
         value = [];
@@ -220,9 +221,9 @@ export default class Drawer extends Vue {
       const title = `${category.name} (${value.length})`;
       const append = `[${size}]`;
       return {
-        icon: 'mdi-folder', title, key: category.key, append,
+        icon: 'mdi-folder-star', title, key: category.key, append,
       };
-    });
+    }));
   }
 
   buildSiteGroup(): MenuChildrenItem[] {

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -156,7 +156,7 @@ export default class Drawer extends Vue {
   ]
 
   endItems: MenuItem[] = [
-    { icon: 'mdi-file-document-outline', title: tr('logs'), click: () => this.updateOptions('showLogs', true) },
+    { icon: 'mdi-math-log', title: tr('logs'), click: () => this.updateOptions('showLogs', true) },
   ]
 
   isDataReady!: boolean
@@ -230,7 +230,7 @@ export default class Drawer extends Vue {
       const size = formatSize(sumBy(value, 'size'));
       const site = SiteMap[key];
       const title = `${site ? site.name : (key || tr('others'))} (${value.length})`;
-      const icon = defaultTo(site ? site.icon : null, 'mdi-server');
+      const icon = defaultTo(site ? site.icon : null, 'mdi-web');
       const append = `[${size}]`;
       return {
         icon, title, key, append,
@@ -282,7 +282,7 @@ export default class Drawer extends Vue {
       select: 'site',
       children: [
         {
-          icon: 'mdi-server', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
+          icon: 'mdi-web', title: `${tr('all')} (${this.allTorrents.length})`, key: null, append: `[${totalSize}]`,
         },
         ...this.buildSiteGroup(),
       ],

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -69,7 +69,7 @@
         v-if="!phoneLayout"
         class="icon-label"
       >
-        <v-icon>mdi-access-point-network</v-icon>
+        <v-icon>mdi-server-network</v-icon>
         {{ $t('label.dht_nodes', info.dht_nodes) }}
       </div>
       <v-divider
@@ -196,9 +196,9 @@ import { Torrent, ServerState } from '../types';
   filters: {
     connectionIcon(status: string) {
       const statusMap: any = {
-        connected: 'server-network',
-        firewalled: 'server-network-off',
-        disconnected: 'security-network',
+        connected: 'ethernet-cable',
+        firewalled: 'wall',
+        disconnected: 'ethernet-cable-off',
       };
       return statusMap[status];
     },

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -69,7 +69,7 @@
         v-if="!phoneLayout"
         class="icon-label"
       >
-        <v-icon>mdi-server-network</v-icon>
+        <v-icon>mdi-lan-connect</v-icon>
         {{ $t('label.dht_nodes', info.dht_nodes) }}
       </div>
       <v-divider

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -31,7 +31,7 @@
         v-if="!phoneLayout"
       />
       <div class="icon-label">
-        <v-icon>mdi-list-status</v-icon>
+        <v-icon>mdi-format-list-text</v-icon>
         {{ allTorrents.length }} [{{ totalSize | formatSize }}]
       </div>
       <v-divider

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -40,7 +40,7 @@
         v-if="!phoneLayout"
       />
       <div class="icon-label">
-        <v-icon>mdi-nas</v-icon>
+        <v-icon>mdi-harddisk-plus</v-icon>
         {{ info.free_space_on_disk | formatSize }}
       </div>
       <v-divider

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -31,7 +31,7 @@
         v-if="!phoneLayout"
       />
       <div class="icon-label">
-        <v-icon>mdi-sprout</v-icon>
+        <v-icon>mdi-list-status</v-icon>
         {{ allTorrents.length }} [{{ totalSize | formatSize }}]
       </div>
       <v-divider
@@ -196,9 +196,9 @@ import { Torrent, ServerState } from '../types';
   filters: {
     connectionIcon(status: string) {
       const statusMap: any = {
-        connected: 'ethernet-cable',
+        connected: 'check-network',
         firewalled: 'wall',
-        disconnected: 'ethernet-cable-off',
+        disconnected: 'close-network',
       };
       return statusMap[status];
     },

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -53,7 +53,7 @@
           :title="$t('info')"
           :disabled="!hasSelected || selectedRows.length > 5"
         >
-          <v-icon>mdi-alert-circle</v-icon>
+          <v-icon>mdi-information</v-icon>
         </v-btn>
         <v-menu offset-y>
           <template v-slot:activator="{ on }">

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -122,7 +122,7 @@
             @click="editTracker"
             :title="$t('title.edit_tracker')"
           >
-            <v-icon>mdi-server</v-icon>
+            <v-icon>mdi-playlist-edit</v-icon>
           </v-btn>
           <v-btn
             icon
@@ -130,7 +130,7 @@
             :title="$t('recheck')"
             :disabled="selectedRows.length == 0"
           >
-            <v-icon>mdi-backup-restore</v-icon>
+            <v-icon>mdi-restore</v-icon>
           </v-btn>
         </template>
       </div>

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -63,7 +63,7 @@
               :title="$t('title.set_category')"
               :disabled="!hasSelected"
             >
-              <v-icon>mdi-view-grid-plus</v-icon>
+              <v-icon>mdi-shape-plus</v-icon>
             </v-btn>
           </template>
           <v-list class="category-actions">
@@ -76,7 +76,7 @@
               @click="setTorrentsCategory(item.key)"
             >
               <v-list-item-action>
-                <v-icon>mdi-view-grid-outline</v-icon>
+                <v-icon>mdi-shape-outline</v-icon>
               </v-list-item-action>
               <v-list-item-content>
                 <v-list-item-title>

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -63,7 +63,7 @@
               :title="$t('title.set_category')"
               :disabled="!hasSelected"
             >
-              <v-icon>mdi-folder-edit</v-icon>
+              <v-icon>mdi-view-grid-plus</v-icon>
             </v-btn>
           </template>
           <v-list class="category-actions">
@@ -76,7 +76,7 @@
               @click="setTorrentsCategory(item.key)"
             >
               <v-list-item-action>
-                <v-icon>mdi-folder-star</v-icon>
+                <v-icon>mdi-view-grid-outline</v-icon>
               </v-list-item-action>
               <v-list-item-content>
                 <v-list-item-title>
@@ -87,7 +87,7 @@
             <v-divider />
             <v-list-item @click="setTorrentsCategory('')">
               <v-list-item-action>
-                <v-icon>mdi-folder-remove</v-icon>
+                <v-icon>mdi-cancel</v-icon>
               </v-list-item-action>
               <v-list-item-content>
                 <v-list-item-title>
@@ -108,7 +108,7 @@
             :title="$t('title.set_location')"
             :disabled="selectedRows.length == 0"
           >
-            <v-icon>mdi-folder-marker</v-icon>
+            <v-icon>mdi-folder-download</v-icon>
           </v-btn>
           <v-btn
             icon

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -63,7 +63,7 @@
               :title="$t('title.set_category')"
               :disabled="!hasSelected"
             >
-              <v-icon>mdi-folder</v-icon>
+              <v-icon>mdi-folder-edit</v-icon>
             </v-btn>
           </template>
           <v-list class="category-actions">

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -40,7 +40,7 @@
           :title="$t('force_start')"
           :disabled="!hasSelected"
         >
-          <v-icon>mdi-play-speed</v-icon>
+          <v-icon>mdi-step-forward</v-icon>
         </v-btn>
 
         <v-divider
@@ -122,7 +122,7 @@
             @click="editTracker"
             :title="$t('title.edit_tracker')"
           >
-            <v-icon>mdi-playlist-edit</v-icon>
+            <v-icon>mdi-vector-polyline-edit</v-icon>
           </v-btn>
           <v-btn
             icon

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -63,7 +63,7 @@
               :title="$t('title.set_category')"
               :disabled="!hasSelected"
             >
-              <v-icon>mdi-folder-star</v-icon>
+              <v-icon>mdi-folder</v-icon>
             </v-btn>
           </template>
           <v-list class="category-actions">
@@ -76,7 +76,7 @@
               @click="setTorrentsCategory(item.key)"
             >
               <v-list-item-action>
-                <v-icon>mdi-folder</v-icon>
+                <v-icon>mdi-folder-star</v-icon>
               </v-list-item-action>
               <v-list-item-content>
                 <v-list-item-title>

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -299,7 +299,7 @@ function getStateInfo(state: string) {
     case 'checkingResumeData':
     case 'moving':
       icon = {
-        icon: 'backup-restore',
+        icon: 'restore',
         color: 'info',
       };
       break;

--- a/src/components/dialogs/EditTrackerDialog.vue
+++ b/src/components/dialogs/EditTrackerDialog.vue
@@ -8,7 +8,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-server</v-icon>
+        <v-icon class="mr-2">mdi-playlist-edit</v-icon>
         <span>Edit tracker</span>
       </v-card-title>
       <v-card-text class="pa-0">

--- a/src/components/dialogs/EditTrackerDialog.vue
+++ b/src/components/dialogs/EditTrackerDialog.vue
@@ -8,7 +8,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-playlist-edit</v-icon>
+        <v-icon class="mr-2">mdi-vector-polyline-edit</v-icon>
         <span>Edit tracker</span>
       </v-card-title>
       <v-card-text class="pa-0">

--- a/src/components/dialogs/InfoDialog.vue
+++ b/src/components/dialogs/InfoDialog.vue
@@ -8,7 +8,7 @@
     <v-card>
       <v-card-title class="headline">
         <v-icon class="mr-2">
-          mdi-alert-circle
+          mdi-information
         </v-icon>
         <span v-text="$t('info')" />
       </v-card-title>

--- a/src/components/dialogs/LogsDialog.vue
+++ b/src/components/dialogs/LogsDialog.vue
@@ -8,7 +8,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-file-document-outline</v-icon>
+        <v-icon class="mr-2">mdi-math-log</v-icon>
         <span v-text="$t('logs')" />
       </v-card-title>
       <v-card-text>

--- a/src/components/dialogs/LogsDialog.vue
+++ b/src/components/dialogs/LogsDialog.vue
@@ -8,7 +8,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-delta</v-icon>
+        <v-icon class="mr-2">mdi-file-document-outline</v-icon>
         <span v-text="$t('logs')" />
       </v-card-title>
       <v-card-text>

--- a/src/components/dialogs/RssDialog.vue
+++ b/src/components/dialogs/RssDialog.vue
@@ -40,7 +40,7 @@
             @click="renameRssItem"
             :title="$t('rename')"
           >
-            <v-icon>mdi-file-move</v-icon>
+            <v-icon>mdi-rename-box</v-icon>
           </v-btn>
           <v-divider vertical />
           <v-btn

--- a/src/components/dialogs/RssDialog.vue
+++ b/src/components/dialogs/RssDialog.vue
@@ -72,7 +72,7 @@
             @click="showRulesDialog = true"
             :title="$t('settings')"
           >
-            <v-icon>mdi-cog-box</v-icon>
+            <v-icon>mdi-cog</v-icon>
           </v-btn>
         </div>
         <v-divider />
@@ -343,7 +343,7 @@ export default class RssDialog extends HasTask {
         return 'mdi-alert'
       }
 
-      return 'mdi-rss'
+      return 'mdi-rss-box'
     }
 
     return row.open ? 'mdi-folder-open' : 'mdi-folder';

--- a/src/components/dialogs/RssDialog.vue
+++ b/src/components/dialogs/RssDialog.vue
@@ -7,7 +7,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-rss-box</v-icon>
+        <v-icon class="mr-2">mdi-rss</v-icon>
         <span>RSS</span>
         <v-spacer />
         <v-btn
@@ -24,7 +24,7 @@
             @click="addRssItem"
             :title="$t('dialog.rss.add_feed')"
           >
-            <v-icon>mdi-link-plus</v-icon>
+            <v-icon>mdi-link-variant-plus</v-icon>
           </v-btn>
           <v-btn
             icon

--- a/src/components/dialogs/RssRulesDialog.vue
+++ b/src/components/dialogs/RssRulesDialog.vue
@@ -7,7 +7,7 @@
   >
     <v-card>
       <v-card-title class="headline">
-        <v-icon class="mr-2">mdi-filter</v-icon>
+        <v-icon class="mr-2">mdi-rss</v-icon>
         <span v-text="$t('dialog.rss_rule.title')" />
         <v-spacer />
         <v-btn

--- a/src/components/dialogs/searchDialog/SearchDialog.vue
+++ b/src/components/dialogs/searchDialog/SearchDialog.vue
@@ -9,7 +9,7 @@
     >
       <v-card>
         <v-card-title class="headline">
-          <v-icon class="mr-2">mdi-text-box-search-outline</v-icon>
+          <v-icon class="mr-2">mdi-text-search</v-icon>
           <span v-text="$t('search')" />
           <v-spacer />
           <v-btn

--- a/src/components/dialogs/searchDialog/SearchDialog.vue
+++ b/src/components/dialogs/searchDialog/SearchDialog.vue
@@ -9,7 +9,7 @@
     >
       <v-card>
         <v-card-title class="headline">
-          <v-icon class="mr-2">mdi-card-search-outline</v-icon>
+          <v-icon class="mr-2">mdi-text-box-search-outline</v-icon>
           <span v-text="$t('search')" />
           <v-spacer />
           <v-btn

--- a/src/components/drawer/DrawerFooter.vue
+++ b/src/components/drawer/DrawerFooter.vue
@@ -80,7 +80,7 @@
         @click="triggerApplicationShutdown"
         :title="$t('trigger_application_shutdown')"
       >
-        <v-icon>mdi-power-plug-off</v-icon>
+        <v-icon>mdi-exit-to-app</v-icon>
       </v-btn>
     </div>
   </div>


### PR DESCRIPTION
This PR updates the following icons:

### Drawer
- [x] settings (`cog-box` to `cog-outline`)
- [x] logs (`delta` to `math-log`) 
- [x] search ( `card-search-outline` to `text-search`)
- [x] sites (`server` to `web`)
- [x] category (If All/Uncategorized → `shape` else `shape-outline`)
- [x] RSS (`rss-box` to `rss`)
- [x] exit (`power-plug-off` to `exit-to-app`)

### Toolbar
- [x] info (`alert-circle` to `information`)
- [x] force start (`play-speed` to `step-forward`)
- [x] tracker edit (`server` to `vector-polyline-edit`)
- [x] recheck (`backup-restore` to `restore`)
- [x] category (`folder-star` to `shape-plus`)
- [x] category - select (`folder` to `shape-outline`)
- [x] category - reset (`folder-remove` to `cancel`)

### RSS modal
- [x] add (`link-plus` to `link-variant-plus`)
- [x] rename (`file-move` to `rename-box`)
- [x] list (`rss` to `rss-box`)
- [x] settings (`cog-box` to `cog`)
- [x] rules modal - heading (`filter` to `rss`)

### Add New modal
- [x] FAB (`link-plus` to `plus`)
*Because torrent files can also be added alongside links.*
- [x] category (per above)
- [x] location (per above)
- [x] hash check (`progress-check`to `data-matrix-scan`)
- [x] start torrent (`play-pause` to `play`)
- [x] sequential dl (`sort-descending` to `sort-ascending`)

### Footer
- [x] total torrents/size (`sprout` to `format-list-text`)
- [x] storage (`nas` to `harddisk-plus`)
- [x] nodes (`access-point-network` to `lan-connect`)
- [x] network - connected (`server-network` to `check-network`)
- [x] network - firewalled (`server-network-off` to `wall`)
- [x] network - disconnected (`security-network` to `close-network`)