### PR TITLE
Add update plugins button to search plugin manager

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -293,6 +293,10 @@ class Api {
 
   // Search page
 
+  public updateSearchPlugins(): Promise<SearchPlugin[]> {
+    return this.axios.post('/search/updatePlugins').then(Api.handleResponse);
+  }
+
   public getSearchPlugins(): Promise<SearchPlugin[]> {
     return this.axios.get('/search/plugins').then(Api.handleResponse);
   }

--- a/src/components/dialogs/searchDialog/PluginsManager.vue
+++ b/src/components/dialogs/searchDialog/PluginsManager.vue
@@ -15,13 +15,21 @@
           @change="togglePluginAvailability(plugin)"
         />
       </v-card-text>
+      <v-card-actions>
+        <v-btn
+          color="warning"
+          @click="updatePlugins()"
+        >
+          {{ $t("update_plugins") }}
+        </v-btn>
+      </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script lang="ts">
 import { SearchEnginePage } from "@/store/types";
-import { SearchPlugin } from '@/types';
+import { SearchPlugin } from "@/types";
 import Vue from "vue";
 import Component from "vue-class-component";
 import { mapActions, mapState } from "vuex";
@@ -35,15 +43,21 @@ import { mapActions, mapState } from "vuex";
   methods: {
     ...mapActions({
       togglePluginAvailabilityAction: "togglePluginAvailability",
+      updatePluginsRequest: "updatePluginsRequest",
     }),
   },
 })
 export default class PluginsManager extends Vue {
   searchEngineState!: SearchEnginePage;
   togglePluginAvailabilityAction!: (_: any) => void;
+  updatePluginsRequest!: () => void;
 
   togglePluginAvailability(plugin: SearchPlugin) {
     this.togglePluginAvailabilityAction(plugin);
+  }
+
+  updatePlugins() {
+    this.updatePluginsRequest();
   }
 }
 </script>

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -65,6 +65,7 @@ export default {
   search_engine: 'Search engine',
   usage: 'usage',
   plugin_manager: 'Plugin manager',
+  update_plugins: 'Update plugins',
 
   title: {
     _: 'Title',

--- a/src/store/searchEngine.ts
+++ b/src/store/searchEngine.ts
@@ -61,5 +61,20 @@ export default {
     enablePluginRequestSuccess({ dispatch }) {
       dispatch('fetchSearchPlugins'); // refresh the plugins
     },
+    async updatePluginsRequest({ dispatch }) {
+      try {
+        await api.updateSearchPlugins();
+
+        dispatch("updatePluginsRequestSuccess");
+      } catch {
+        dispatch("updatePluginsRequestFailure");
+      }
+    },
+    async updatePluginsRequestSuccess({ dispatch }) {
+      await dispatch('getSearchPluginsRequest');
+    },
+    updatePluginsRequestFailure() {
+      // Do nothing
+    },
   },
 } as Module<SearchEnginePage, any>;


### PR DESCRIPTION
Will remove the necessary switching to the old client to enable default installed plugins.

![image](https://user-images.githubusercontent.com/15037947/103099970-3313e280-4619-11eb-8963-09a6fdf9162f.png)
