### PR TITLE
implemented updating search result on every query

### DIFF
--- a/src/components/dialogs/searchDialog/SearchDialog.vue
+++ b/src/components/dialogs/searchDialog/SearchDialog.vue
@@ -190,8 +190,8 @@ export default class SearchDialog extends HasTask {
       const response = await api.getSearchResults(responseId);
       const isStopped = response.status === "Stopped";
 
+      this.grid.searchItems = this.grid.searchItems.concat(response.results.slice(this.grid.searchItems.length,response.results.length))
       if (isStopped) {
-        this.grid.searchItems = this.grid.searchItems.concat(response.results);
         this.loading = false;
       }
 

--- a/src/components/dialogs/searchDialog/SearchDialog.vue
+++ b/src/components/dialogs/searchDialog/SearchDialog.vue
@@ -190,7 +190,7 @@ export default class SearchDialog extends HasTask {
       const response = await api.getSearchResults(responseId);
       const isStopped = response.status === "Stopped";
 
-      this.grid.searchItems = this.grid.searchItems.concat(response.results.slice(this.grid.searchItems.length,response.results.length))
+      this.grid.searchItems.splice(-1, 0, ...response.results.slice(this.grid.searchItems.length))
       if (isStopped) {
         this.loading = false;
       }


### PR DESCRIPTION
This change allows UI to display already obtained search results while waiting for search to complete, the results sticks there even if you cancel search midway, this is how it works on the qbittorents original web UI and I think its nice to have for UX so I implemented for this web ui as well