### PR TITLE
Fix category savePath in AddForm

### DIFF
--- a/src/components/AddForm.vue
+++ b/src/components/AddForm.vue
@@ -275,7 +275,8 @@ export default class AddForm extends Vue {
     return this.allCategories.map(c => ({ text: c.name, value: c.key }));
   }
   get defaultPath() {
-    if (this.params.autoTMM && this.params.category) {
+
+    if (this.params.category) {
       const category = this.allCategories.find(c => {
         return c.key === this.params.category;
       });


### PR DESCRIPTION
Seems like the Auto TTM is preventing to change the `savePath` when a category is selected and that way the `savePath` is always the default one for the app. 

I am not entirely sure that this is the best fix for this but seems to work with `manual` and `auto`. 