### PR TITLE
add GroupBySavePath

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
       :clipped="$vuetify.breakpoint.lgAndUp"
       v-model="drawer"
       v-class:phone-layout="phoneLayout"
-      width="300"
+      width="400"
     >
       <drawer v-model="drawerOptions" />
 

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -65,7 +65,7 @@ import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
 import { tr } from '@/locale';
-import { Torrent, Category } from '@/types';
+import { Torrent, Category, RootPath } from '@/types';
 import FilterGroup from './drawer/FilterGroup.vue';
 import api from '../Api';
 import { formatSize } from '@/filters';
@@ -144,6 +144,7 @@ interface MenuChildrenItem extends MenuItem {
       'torrentGroupByCategory',
       'torrentGroupBySite',
       'torrentGroupByState',
+      'torrentGroupBySavePath',
     ]),
   },
 })
@@ -168,6 +169,7 @@ export default class Drawer extends Vue {
   torrentGroupByCategory!: {[category: string]: Torrent[]}
   torrentGroupBySite!: {[site: string]: Torrent[]}
   torrentGroupByState!: {[state: string]: Torrent[]}
+  torrentGroupBySavePath!: RootPath
 
   created() {
    if (this.phoneLayout) {
@@ -227,6 +229,20 @@ export default class Drawer extends Vue {
     }), 'title');
   }
 
+
+  buildSavePathGroup(): MenuChildrenItem[] {
+    return sortBy(Object.entries(this.torrentGroupBySavePath.link).map(([key, value]) => {
+      const size = formatSize(value.size);
+      const realSize = formatSize(value.realSize);
+      const title = `${key} (${value.torrents.length})`;
+      const icon = value.torrents.length ? 'mdi-folder' : 'mdi-folder-outline';
+      const append = `[${realSize} | ${size}]`;
+      return {
+        icon, title, key, append,
+      };
+    }), 'title');
+  }
+
   get items() {
     if (!this.isDataReady) {
       return this.endItems
@@ -275,6 +291,15 @@ export default class Drawer extends Vue {
         },
         ...this.buildSiteGroup(),
       ],
+    });
+
+    filterGroups.push({
+      icon: 'mdi-menu-up',
+      'icon-alt': 'mdi-menu-down',
+      title: tr('savePath'),
+      model: null,
+      select: 'savePath',
+      children: this.buildSavePathGroup(),
     });
 
     return ([] as MenuItem[]).concat([{filterGroups}] as any, this.endItems);

--- a/src/components/Torrents.vue
+++ b/src/components/Torrents.vue
@@ -248,7 +248,7 @@ import api from '../Api'
 import { formatSize } from '@/filters'
 import { DialogType, TorrentFilter, ConfigPayload, DialogConfig, SnackBarConfig } from '@/store/types'
 import Component from 'vue-class-component'
-import { Torrent, Category } from '@/types'
+import { Torrent, Category, RootPath } from '@/types'
 import { Watch } from 'vue-property-decorator'
 
 function getStateInfo(state: string) {
@@ -341,6 +341,7 @@ function getStateInfo(state: string) {
       'torrentGroupByCategory',
       'torrentGroupBySite',
       'torrentGroupByState',
+      'torrentGroupBySavePath',
     ]),
     ...mapState({
       filter(state, getters) {
@@ -416,6 +417,7 @@ export default class Torrents extends Vue {
   torrentGroupByCategory!: {[category: string]: Torrent[]}
   torrentGroupBySite!: {[site: string]: Torrent[]}
   torrentGroupByState!: {[state: string]: Torrent[]}
+  torrentGroupBySavePath!: RootPath
   filter!: TorrentFilter
 
   updateConfig!: (_: ConfigPayload) => void
@@ -446,6 +448,12 @@ export default class Torrents extends Vue {
     }
     if (this.filter.state !== null) {
       list = intersection(list, this.torrentGroupByState[this.filter.state]);
+    }
+    if (this.filter.savePath !== null) {
+      list = intersection(list, this.torrentGroupBySavePath.link[this.filter.savePath].torrents);
+      // walkdir(this.torrentGroupBySavePath.link[this.filter.savePath], dir => {
+      //   list = intersection(list, dir.torrents);
+      // });
     }
     if (this.filter.query) {
       const q = this.filter.query.toLowerCase();

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -55,6 +55,7 @@ export default {
   uncategorized: 'Uncategorized',
   others: 'Others',
   sites: 'Sites',
+  savePath: 'Save Path',
   files: 'Files',
   less: 'Less',
   more: 'More',

--- a/src/locale/ru.ts
+++ b/src/locale/ru.ts
@@ -54,6 +54,7 @@ export default {
   uncategorized: 'Без категории',
   others: 'Другие',
   sites: 'Сайты',
+  savePath: 'Путь сохранения',
   files: 'Файлы',
   less: 'Меньше',
   more: 'Больше',

--- a/src/locale/tr.ts
+++ b/src/locale/tr.ts
@@ -54,6 +54,7 @@ export default {
   uncategorized: 'Kategorilenmemiş',
   others: 'Diğerleri',
   sites: 'Siteler',
+  savePath: 'Dizini Kaydet',
   files: 'Dosyalar',
   less: 'Daha Az',
   more: 'Daha Çok',

--- a/src/locale/zh-CN.ts
+++ b/src/locale/zh-CN.ts
@@ -55,6 +55,7 @@ export default {
   uncategorized: '未分类',
   others: '其他',
   sites: '站点',
+  savePath: '保存路径',
   files: '文件',
   less: '更少',
   more: '更多',

--- a/src/locale/zh-TW.ts
+++ b/src/locale/zh-TW.ts
@@ -56,6 +56,7 @@ export default {
   others: '其他',
   sites: '站點',
   files: '文件',
+  savePath: '保存路徑',
   less: '更少',
   more: '更多',
   feed: '訂閱',

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -14,6 +14,7 @@ export interface Config {
     category: string | null;
     site: string | null;
     query: string | null;
+    savePath: string | null;
   };
   locale: string | null;
   darkMode: string | null;
@@ -31,6 +32,7 @@ const defaultConfig = {
     category: null,
     site: null,
     query: null,
+    savePath: null,
   },
   locale: null,
   darkMode: null,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import searchEngineStore from './searchEngine';
 import { RootState } from './types';
 import stateMerge from '@/utils/vue-object-merge';
 import api from '@/Api';
+import { buildSavePlace } from '@/utils/save-place'
 
 Vue.use(Vuex);
 
@@ -85,6 +86,9 @@ const store = new Vuex.Store<RootState>({
 
       return map(state.mainData.torrents, (value, key) => merge({}, value, { hash: key }));
     },
+    torrentGroupBySavePath(__, getters) {
+      return buildSavePlace(getters.allTorrents);
+    },
     allCategories(state) {
       if (!state.mainData) {
         return [];
@@ -156,7 +160,7 @@ export function useStore() {
 }
 
 export function useMutations(mutations: [string], namespace?: string) {
-  const result: {[key: string]: () => any} = {};
+  const result: { [key: string]: () => any } = {};
 
   mutations.forEach((m) => {
     const method = namespace ? `${namespace}/${m}` : m;
@@ -169,7 +173,7 @@ export function useMutations(mutations: [string], namespace?: string) {
 export function useState(states: [string], namespace?: string) {
   const state = namespace ? (store.state as any)[namespace] : store.state;
 
-  const result: {[key: string]: Readonly<Ref<Readonly<any>>>} = {};
+  const result: { [key: string]: Readonly<Ref<Readonly<any>>> } = {};
 
   states.forEach((s) => {
     result[s] = computed(() => state[s]);

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -27,6 +27,7 @@ export interface TorrentFilter {
   category: string;
   site: string;
   query: string;
+  savePath: string | null;
 }
 
 export interface ConfigState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,19 @@ export interface Torrent extends BaseTorrent {
   hash: string;
 }
 
+export interface SavePlace {
+  key: string;
+  dirname: [string,...string[]];
+  torrents: Torrent[];
+  size: number;
+  realSize: number;
+  subdirs: SavePlace[];
+}
+
+export interface RootPath extends SavePlace {
+  link: Record<string, SavePlace>;
+}
+
 export interface Category {
   key: string;
   name: string;

--- a/src/utils/save-place.ts
+++ b/src/utils/save-place.ts
@@ -1,0 +1,116 @@
+import { RootPath, SavePlace, Torrent } from '@/types';
+import { startsWith, sortBy, reduce, split, has, forEach, sumBy, trimEnd, uniqBy } from 'lodash';
+
+const PATH_SEP = '/'
+
+export function walkdir(dir: SavePlace, fn: (dir: SavePlace) => void): void {
+  fn(dir);
+  forEach(dir.subdirs, (dir) => walkdir(dir, fn));
+}
+
+function mergeNode(links: Record<string, SavePlace>, prefix: string[], intree: SavePlace, newNode: SavePlace): SavePlace {
+  if (startsWith(intree.key, newNode.key)) {
+    intree.dirname.splice(0, newNode.dirname.length);
+    newNode.subdirs.push(intree);
+    return newNode;
+  }
+  if (startsWith(newNode.key, intree.key)) {
+    newNode.dirname.splice(0, intree.dirname.length);
+    intree.subdirs.push(newNode);
+    intree.subdirs = sortBy(intree.subdirs, x => x.key);
+    return intree;
+  }
+  const parentDirname: string[] = prefix;
+  const minLength = Math.min(intree.dirname.length, newNode.dirname.length);
+  let index = 0;
+  for (; index < minLength; ++index) {
+    if (intree.dirname[index] !== newNode.dirname[index]) {
+      index -= 1;
+      break;
+    }
+    parentDirname.push(intree.dirname[index]);
+  }
+  const key = parentDirname.join(PATH_SEP);
+  intree.dirname.splice(0, parentDirname.length);
+  newNode.dirname.splice(0, parentDirname.length);
+  const sharedParent: SavePlace = {
+    key,
+    size: 0,
+    realSize: 0,
+    dirname: parentDirname as [string, ...string[]],
+    torrents: [],
+    subdirs: sortBy([newNode, intree], 'key'),
+  };
+  links[key] = sharedParent;
+  return sharedParent;
+}
+
+function countSameSegment(segs0: string[], segs1: string[]): number {
+  let n = 0;
+  while(segs0[n]!=undefined && segs1[n] !== undefined && segs0[n] === segs1[n]) n++;
+  return n;
+}
+
+function insertNode(links: Record<string, SavePlace>, prefix: string[], parent: SavePlace, newNode: SavePlace) {
+  const tIndex = reduce(parent.subdirs, ([maxSameSegment, bestIndex], item, index) => {
+    const sames = countSameSegment(item.dirname, newNode.dirname);
+    if (sames > maxSameSegment) {
+      return [sames, index];
+    }
+    return [maxSameSegment, bestIndex];
+  }, [0, -1])[1];
+  if (tIndex === -1) {
+    parent.subdirs.push(newNode);
+    return;
+  }
+  const t = parent.subdirs[tIndex];
+  if (t.key === newNode.key) {
+    t.torrents.push(newNode.torrents[0]);
+    return;
+  }
+  if (startsWith(newNode.key, t.key)) {
+    prefix.push(...newNode.dirname.splice(0, t.dirname.length));
+    insertNode(links, prefix, t, newNode);
+  } else {
+    parent.subdirs[tIndex] = mergeNode(links, prefix, t, newNode);
+  }
+}
+
+function calcSize(node: SavePlace) {
+  forEach(node.subdirs, calcSize);
+  node.size = sumBy(node.torrents, 'size') + sumBy(node.subdirs, 'size');
+  node.realSize = sumBy(uniqBy(node.torrents, 'name'), 'size') + sumBy(node.subdirs, 'realSize');
+}
+
+export function buildSavePlace(torrents?: Torrent[]): RootPath {
+  const root: RootPath = {
+    key: '',
+    size: 0,
+    realSize: 0,
+    link: {},
+    dirname: [''],
+    subdirs: [],
+    torrents: [],
+  };
+  if (!torrents) {
+    return root;
+  }
+  for (const torrent of torrents) {
+    const newNode: SavePlace = {
+      key: trimEnd(torrent.save_path, PATH_SEP),
+      dirname: split(trimEnd(torrent.save_path, PATH_SEP), PATH_SEP) as [string, ...string[]],
+      torrents: [torrent],
+      size: 0,
+      realSize: 0,
+      subdirs: [],
+    };
+    if (has(root.link, newNode.key)) {
+      root.link[newNode.key].torrents.push(torrent);
+      continue;
+    }
+    root.link[newNode.key] = newNode;
+    insertNode(root.link, [], root, newNode);
+  }
+  calcSize(root);
+  return root;
+}

--- a/tests/unit/save-place.spec.ts
+++ b/tests/unit/save-place.spec.ts
@@ -1,0 +1,29 @@
+import { buildSavePlace } from '@/utils/save-place';
+import { mockTorrent } from './utils'
+
+describe('save-place', () => {
+  test('case #1', () => {
+    const root = buildSavePlace();
+    expect(root).toStrictEqual({
+      key: '',
+      link: {},
+      realSize: 0,
+      size: 0,
+      dirname: [''],
+      torrents: [],
+      subdirs: [],
+    });
+  });
+  test('case #2', () => {
+    const root = buildSavePlace([
+      '/home/user/downloads/a/aa/aaa',
+      '/home/user/downloads/a/aa/bbb',
+      '/home/user/downloads/a/bb/bbb',
+      '/home/user/downloads/b/cc/ccc',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    ].map(x => mockTorrent({save_path: x})));
+    expect(root.subdirs.length).toBe(1);
+    expect(root.subdirs[0].key).toBe('/home/user/downloads');
+    expect(root.subdirs[0].subdirs.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Add a `save_path` filter into drawer.
Users can easy know the disk space usage
In teamplate: left `<path> (torrent count)`, right `[ real disk usage | disk usage ])`
- torrent count is not include subdirs.
- disk usage is include subdirs.

Preview:
![image](https://user-images.githubusercontent.com/7581607/169578567-5119579d-90ea-44a6-814c-33c01e26d7e9.png)
