### PR TITLE
Fix duplicated translation line

### DIFF
--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -124,7 +124,7 @@ export default {
     web_ui_username: 'Username',
     web_ui_password: 'Password',
     bypass_local_auth: 'Bypass authentication for clients on localhost',
-    bypass_auth_subnet_whitelist: 'Bypass authentication for clients on localhost',
+    bypass_auth_subnet_whitelist: 'Bypass authentication for clients in whitelisted IP subnets',
     web_ui_session_timeout: 'Session timeout',
     web_ui_max_auth_fail_count: 'Ban client after consecutive failures',
     web_ui_ban_duration: 'ban for',


### PR DESCRIPTION
See #142. Line 127 of this file was using the same translation as the line above it, leading to the following: 
![image](https://user-images.githubusercontent.com/174944/179922345-73353aba-e05c-4711-b35c-ad80245b9504.png)

This PR corrects the translation.