### PR TITLE
Enable all Drawer menu items for mobile users

### DIFF
--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -182,10 +182,6 @@ export default class Drawer extends Vue {
   torrentGroupByState!: {[state: string]: Torrent[]}
 
   created() {
-   if (this.phoneLayout) {
-      return;
-    }
-
     this.endItems = this.endItems.concat(this.pcItems)
   }
 

--- a/src/components/dialogs/RssDialog.vue
+++ b/src/components/dialogs/RssDialog.vue
@@ -544,6 +544,16 @@ export default class RssDialog extends HasTask {
 
     display: flex;
   }
+
+}
+
+@media (max-width: 800px) {
+  .content {
+      .content-inner {
+        display: grid;
+        grid-template-rows: auto auto 1fr auto;
+      }
+  }
 }
 
 .rss-items {


### PR DESCRIPTION
When browsing via mobile you do not have access to some items of the drawers (RSS and settings). 

This PR enable RSS browsing via mobile and changes the dialog layout to a mono-column layout.