### PR TITLE
Fix RSS details list

### DIFF
--- a/src/components/dialogs/RssDialog.vue
+++ b/src/components/dialogs/RssDialog.vue
@@ -553,7 +553,6 @@ export default class RssDialog extends HasTask {
 
 .rss-details {
   flex: 40%;
-  height: 100%;
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
#170

去掉了 `.rss-details` 的 `height: 100%` 似乎就解决这个问题了。在 RSS 的 dialog 里，`.rss-details` 两边同样是竖直方向撑满的 `.rss-items` 和 `.rss-desc` 都没有设定 `height`。